### PR TITLE
Add running choanoflagellates

### DIFF
--- a/nf-kmer-similarity/Makefile
+++ b/nf-kmer-similarity/Makefile
@@ -9,9 +9,10 @@ merkin2012_aws:
 		-profile aws
 
 merkin2012_local:
-	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
-		-r olgabot/support-csv-directory-or-sra \
-		-profile local
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+                -r olgabot/support-csv-directory-or-sra \
+		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
+                -profile local
 
 
 choanoflagellates:
@@ -24,4 +25,5 @@ choanoflagellates_local:
 	nextflow run czbiohub/nf-kmer-similarity \
 	 	-r olgabot/support-csv-directory-or-sra \
 		-latest --sra "PRJNA419411" \
+		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
 		-profile local

--- a/nf-kmer-similarity/Makefile
+++ b/nf-kmer-similarity/Makefile
@@ -3,9 +3,15 @@ human_mouse_zebrafish:
 		--samples s3://kmer-hashing/hematopoeisis/smartseq2/human_mouse_zebrafish/samples.csv
 
 
-merkin2012:
+merkin2012_aws:
 	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
 		-profile aws
+
+merkin2012_local:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile local
 
 
 choanoflagellates:

--- a/nf-kmer-similarity/Makefile
+++ b/nf-kmer-similarity/Makefile
@@ -9,10 +9,13 @@ merkin2012:
 
 
 choanoflagellates:
-	nextflow run czbiohub/nf-kmer-similarity -latest --sra "PRJNA419411" \
+	nextflow run czbiohub/nf-kmer-similarity \
+		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
 		-profile aws
 
 
 choanoflagellates_local:
-	nextflow run czbiohub/nf-kmer-similarity -latest --sra "PRJNA419411" \
+	nextflow run czbiohub/nf-kmer-similarity \
+	 	-r olgabot/support-csv-directory-or-sra \
+		-latest --sra "PRJNA419411" \
 		-profile local

--- a/nf-kmer-similarity/Makefile
+++ b/nf-kmer-similarity/Makefile
@@ -4,4 +4,15 @@ human_mouse_zebrafish:
 
 
 merkin2012:
-	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" -profile aws
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-profile aws
+
+
+choanoflagellates:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "PRJNA419411" \
+		-profile aws
+
+
+choanoflagellates_local:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "PRJNA419411" \
+		-profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -37,3 +37,9 @@ transcriptomes:
                 -latest --fastas '/home/olga/data/figshare/choanoflagellates_richter2018/1_choanoflagellate_transcriptomes/*.fasta' \
 		-resume \
                 -profile local
+
+
+sync_transcriptomes:
+	aws s3 sync \
+		~/data/kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/ \
+		s3://kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -10,7 +10,7 @@ aws:
 
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
-		--outdir s3://kmer-hashing/choanoflagellates/richter2018/ \
+		--outdir s3://kmer-hashing/choanoflagellates/richter2018/rawreads/ \
 	 	-r olgabot/support-csv-directory-or-sra \
 		-latest --sra "PRJNA419411" \
 		-work-dir /mnt/pureScratch/olga/nextflow/ \
@@ -18,3 +18,12 @@ local:
 
 move_workdir:
 	ls -1 ${D1} | xargs -I {} -P 8 -n 1 sudo rsync -avh ${D1}/{} ${D2}
+
+transcriptomes:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
+                --outdir s3://kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/ \
+                -r olgabot/support-csv-directory-or-sra \
+		--molecules dna \
+                -latest --directories /mnt/ibm_lg/olga/figshare/choanoflagellates_richter2018/1_choanoflagellate_transcriptomes/*.fasta \
+                -work-dir /mnt/pureScratch/olga/nextflow/ \
+                -profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -1,11 +1,12 @@
-choanoflagellates:
+aws:
 	nextflow run czbiohub/nf-kmer-similarity \
 		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
 		-profile aws
 
 
-choanoflagellates_local:
-	nextflow run czbiohub/nf-kmer-similarity \
+local:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
 	 	-r olgabot/support-csv-directory-or-sra \
 		-latest --sra "PRJNA419411" \
+		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
 		-profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -1,0 +1,11 @@
+choanoflagellates:
+	nextflow run czbiohub/nf-kmer-similarity \
+		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
+		-profile aws
+
+
+choanoflagellates_local:
+	nextflow run czbiohub/nf-kmer-similarity \
+	 	-r olgabot/support-csv-directory-or-sra \
+		-latest --sra "PRJNA419411" \
+		-profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -1,3 +1,7 @@
+D1=work
+D2=/mnt/pureScratch/olga/nextflow
+
+
 aws:
 	nextflow run czbiohub/nf-kmer-similarity \
 		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
@@ -6,7 +10,11 @@ aws:
 
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
+		--outdir s3://kmer-hashing/choanoflagellates/richter2018/ \
 	 	-r olgabot/support-csv-directory-or-sra \
 		-latest --sra "PRJNA419411" \
-		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
+		-work-dir /mnt/pureScratch/olga/nextflow/ \
 		-profile local
+
+move_workdir:
+	ls -1 ${D1} | xargs -I {} -P 8 -n 1 sudo rsync -avh ${D1}/{} ${D2}

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -24,6 +24,5 @@ transcriptomes:
                 --outdir s3://kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/ \
                 -r olgabot/support-csv-directory-or-sra \
 		--molecules dna \
-                -latest --directories /mnt/ibm_lg/olga/figshare/choanoflagellates_richter2018/1_choanoflagellate_transcriptomes/*.fasta \
-                -work-dir /mnt/pureScratch/olga/nextflow/ \
+                -latest --fastas '/home/olga/data/figshare/choanoflagellates_richter2018/1_choanoflagellate_transcriptomes/*.fasta' \
                 -profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile
+++ b/nf-kmer-similarity/choanoflagellates/Makefile
@@ -10,19 +10,30 @@ aws:
 
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
-		--outdir s3://kmer-hashing/choanoflagellates/richter2018/rawreads/ \
+		--outdir ~/data/kmer-hashing/choanoflagellates/richter2018/rawreads/ \
 	 	-r olgabot/support-csv-directory-or-sra \
 		-latest --sra "PRJNA419411" \
 		-work-dir /mnt/pureScratch/olga/nextflow/ \
 		-profile local
+
+sra_local:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
+		--outdir ~/data/kmer-hashing/choanoflagellates/richter2018/rawreads/ \
+	 	-r olgabot/support-csv-directory-or-sra \
+		-latest \
+		-resume \
+		--read_pairs '/home/olga/data/sra-explorer/choanoflagellates/*{1,2}.fastq.gz' \
+		-profile local
+
 
 move_workdir:
 	ls -1 ${D1} | xargs -I {} -P 8 -n 1 sudo rsync -avh ${D1}/{} ${D2}
 
 transcriptomes:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity \
-                --outdir s3://kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/ \
+                --outdir ~/data/kmer-hashing/choanoflagellates/richter2018/assembled_transcriptomes/ \
                 -r olgabot/support-csv-directory-or-sra \
-		--molecules dna \
+		--molecules dna,protein \
                 -latest --fastas '/home/olga/data/figshare/choanoflagellates_richter2018/1_choanoflagellate_transcriptomes/*.fasta' \
+		-resume \
                 -profile local

--- a/nf-kmer-similarity/choanoflagellates/Makefile~
+++ b/nf-kmer-similarity/choanoflagellates/Makefile~
@@ -1,0 +1,27 @@
+human_mouse_zebrafish:
+	nextflow run czbiohub/nf-kmer-similarity -latest -profile aws \
+		--samples s3://kmer-hashing/hematopoeisis/smartseq2/human_mouse_zebrafish/samples.csv
+
+
+merkin2012_aws:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile aws
+
+merkin2012_local:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile local
+
+
+choanoflagellates:
+	nextflow run czbiohub/nf-kmer-similarity \
+		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
+		-profile aws
+
+
+choanoflagellates_local:
+	nextflow run czbiohub/nf-kmer-similarity \
+	 	-r olgabot/support-csv-directory-or-sra \
+		-latest --sra "PRJNA419411" \
+		-profile local

--- a/nf-kmer-similarity/human_mouse_zebrafish/Makefile
+++ b/nf-kmer-similarity/human_mouse_zebrafish/Makefile
@@ -1,0 +1,4 @@
+run_aws:
+	nextflow run czbiohub/nf-kmer-similarity -latest -profile aws \
+		--samples s3://kmer-hashing/hematopoeisis/smartseq2/human_mouse_zebrafish/samples.csv
+

--- a/nf-kmer-similarity/human_mouse_zebrafish/Makefile~
+++ b/nf-kmer-similarity/human_mouse_zebrafish/Makefile~
@@ -1,0 +1,27 @@
+human_mouse_zebrafish:
+	nextflow run czbiohub/nf-kmer-similarity -latest -profile aws \
+		--samples s3://kmer-hashing/hematopoeisis/smartseq2/human_mouse_zebrafish/samples.csv
+
+
+merkin2012_aws:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile aws
+
+merkin2012_local:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile local
+
+
+choanoflagellates:
+	nextflow run czbiohub/nf-kmer-similarity \
+		-r olgabot/support-csv-directory-or-sra -latest --sra "PRJNA419411" \
+		-profile aws
+
+
+choanoflagellates_local:
+	nextflow run czbiohub/nf-kmer-similarity \
+	 	-r olgabot/support-csv-directory-or-sra \
+		-latest --sra "PRJNA419411" \
+		-profile local

--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -6,7 +6,7 @@ aws:
 		-r olgabot/support-csv-directory-or-sra \
 		-profile aws
 
-local:
+sra_local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
 		--outdir s3://kmer-hashing/multispecies/merkin2012/ \
                 -r olgabot/support-csv-directory-or-sra \
@@ -15,5 +15,13 @@ local:
 
 move_workdir:
 	ls -1 ${D1} | xargs -I {} -P 8 -n 1 sudo rsync -avh ${D1}/{} ${D2}
+
+
+local:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest \
+		--read_pairs /home/olga/data/sra-explorer/merkin2012/*{1,2}.fastq.gz \
+		--outdir s3://kmer-hashing/multispecies/merkin2012/ \
+                -r olgabot/support-csv-directory-or-sra \
+                -profile local
 
 

--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -20,7 +20,7 @@ move_workdir:
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest \
 		--read_pairs /home/olga/data/sra-explorer/merkin2012/*{1,2}.fastq.gz \
-		--outdir s3://kmer-hashing/multispecies/merkin2012/ \
+		--outdir /home/olga/data/kmer-hashing/multispecies/merkin2012/ \
                 -r olgabot/support-csv-directory-or-sra \
                 -profile local
 

--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -1,3 +1,6 @@
+D1=/mnt/ibm_lg/olga/nextflow-workdir
+D2=/mnt/pureScratch/olga/nextflow
+
 aws:
 	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
 		-r olgabot/support-csv-directory-or-sra \
@@ -5,7 +8,12 @@ aws:
 
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		--outdir s3://kmer-hashing/multispecies/merkin2012/ \
                 -r olgabot/support-csv-directory-or-sra \
-		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
+		-work-dir /mnt/pureScratch/olga/nextflow/ \
                 -profile local
+
+move_workdir:
+	ls -1 ${D1} | xargs -I {} -P 8 -n 1 sudo rsync -avh ${D1}/{} ${D2}
+
 

--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -25,3 +25,7 @@ local:
                 -profile local
 
 
+sync:
+	aws s3 sync \
+		/home/olga/data/kmer-hashing/multispecies/merkin2012 \
+		s3://kmer-hashing/multispecies/merkin2012/

--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -1,0 +1,11 @@
+aws:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile aws
+
+local:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+                -r olgabot/support-csv-directory-or-sra \
+		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
+                -profile local
+

--- a/nf-kmer-similarity/merkin2012/Makefile~
+++ b/nf-kmer-similarity/merkin2012/Makefile~
@@ -1,0 +1,11 @@
+run_aws:
+	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+		-r olgabot/support-csv-directory-or-sra \
+		-profile aws
+
+run_local:
+	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
+                -r olgabot/support-csv-directory-or-sra \
+		-work-dir /mnt/ibm_lg/olga/nextflow-workdir/ \
+                -profile local
+

--- a/nf-kmer-similarity/nextflow.config
+++ b/nf-kmer-similarity/nextflow.config
@@ -25,7 +25,7 @@ profiles {
     process.executor = 'awsbatch'
     process.queue = 'nextflow'
     executor.awscli = '/home/ec2-user/miniconda/bin/aws'
-    workDir = 's3://czb-nextflow/work'
+    workDir = 's3://kmer-hashing/nextflow-intermediates/'
     docker.enabled = true
   }
 }


### PR DESCRIPTION
Run kmer-hashing on the data from this paper: https://elifesciences.org/articles/34226

## Gene family innovation, conservation and loss on the animal stem lineage

Daniel J Richter, Parinaz Fozouni, Michael B Eisen, Nicole King

### Abstract
Choanoflagellates, the closest living relatives of animals, can provide unique insights into the changes in gene content that preceded the origin of animals. However, only two choanoflagellate genomes are currently available, providing poor coverage of their diversity. We sequenced transcriptomes of 19 additional choanoflagellate species to produce a comprehensive reconstruction of the gains and losses that shaped the ancestral animal gene repertoire. We identified ~1944 gene families that originated on the animal stem lineage, of which only 39 are conserved across all animals in our study. In addition, ~372 gene families previously thought to be animal-specific, including Notch, Delta, and homologs of the animal Toll-like receptor genes, instead evolved prior to the animal-choanoflagellate divergence. Our findings contribute to an increasingly detailed portrait of the gene families that defined the biology of the Urmetazoan and that may underpin core features of extant animals.


The 20 transcriptomes of 19 species are under `PRJNA419411 `

### Figshare

doi:10.6084/m9.fig-share.5686984.v2 - https://figshare.com/articles/Data_from_The_ancestral_animal_genetic_toolkit_revealed_by_diverse_choanoflagellate_transcriptomes/5686984/2