### PR TITLE
Fix merkin2012 makefile

### DIFF
--- a/nf-kmer-similarity/merkin2012/Makefile
+++ b/nf-kmer-similarity/merkin2012/Makefile
@@ -3,13 +3,11 @@ D2=/mnt/pureScratch/olga/nextflow
 
 aws:
 	nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
-		-r olgabot/support-csv-directory-or-sra \
 		-profile aws
 
 sra_local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest --sra "SRP016501" \
-		--outdir s3://kmer-hashing/multispecies/merkin2012/ \
-                -r olgabot/support-csv-directory-or-sra \
+		--outdir s3://kmer-hashing/merkin2012/ \
 		-work-dir /mnt/pureScratch/olga/nextflow/ \
                 -profile local
 
@@ -20,12 +18,11 @@ move_workdir:
 local:
 	sudo /home/olga/bin/nextflow run czbiohub/nf-kmer-similarity -latest \
 		--read_pairs /home/olga/data/sra-explorer/merkin2012/*{1,2}.fastq.gz \
-		--outdir /home/olga/data/kmer-hashing/multispecies/merkin2012/ \
-                -r olgabot/support-csv-directory-or-sra \
+		--outdir /home/olga/data/kmer-hashing/merkin2012/ \
                 -profile local
 
 
 sync:
 	aws s3 sync \
-		/home/olga/data/kmer-hashing/multispecies/merkin2012 \
-		s3://kmer-hashing/multispecies/merkin2012/
+		/home/olga/data/kmer-hashing/merkin2012 \
+		s3://kmer-hashing/merkin2012/


### PR DESCRIPTION
- remove dependence on `olgabot/support-csv-directory-or-sra` branch of [czbiohub/nf-kmer-similarity](github.com/czbiohub/nf-kmer-similarity)
- output to s3://kmer-hashing/merkin2012 rather than s3://kmer-hashing/multispecies/merkin2012 since there's other multispecies stuff too