### PR TITLE
Run extract_coding on all of ENSEMBL97

### DIFF
--- a/kmermaid/Makefile
+++ b/kmermaid/Makefile
@@ -1,19 +1,13 @@
+REPO=~/code/nf-core/extractcoding--olgabot/khtools-extract-coding-long-reads
+
 lrrr:
 	nextflow run \
-                nf-core/kmermaid \
-                -r 818a148 \
+		${REPO} \
 		-profile czbiohub_local,docker \
-		--fastas ~/data_lg/czbiohub-reference/ensembl/release-97/fasta/**cdna.all.fa.gz \
+		--reads '/home/olga/data_lg/czbiohub-reference/ensembl/release-97/fasta/**cdna.all.fa.gz' \
 		--custom_config_base ~/code/nf-core/configs \
-		--molecules dna,protein,dayhoff \
 		--peptide_fasta ~/data_lg/czbiohub-reference/ensembl/release-97/fasta/homo_sapiens/pep/Homo_sapiens.GRCh38.pep.all.fa.gz \
-		--ksizes 21 \
-		--log2_sketch_sizes 5 \
-		--extract_coding_peptide_ksize 7 \
-		--extract_coding_peptide_molecule protein \
-		--outdir ~/data_sm/kmer-hashing/kmermaid-extract-coding-ensembl97/ \
-		--extract_coding_jaccard_threshold 0.5 \
 		-work-dir ~/data_sm/olga-lrrr/nextflow-intermediates-nosudo/ \
-		--max_cpus 120 \
-		--max_time 720.h \
-		-resume
+		-resume \
+		--singleEnd \
+		-with-tower

--- a/kmermaid/Makefile
+++ b/kmermaid/Makefile
@@ -1,0 +1,19 @@
+lrrr:
+	nextflow run \
+                nf-core/kmermaid \
+                -r 818a148 \
+		-profile czbiohub_local,docker \
+		--fastas ~/data_lg/czbiohub-reference/ensembl/release-97/fasta/**cdna.all.fa.gz \
+		--custom_config_base ~/code/nf-core/configs \
+		--molecules dna,protein,dayhoff \
+		--peptide_fasta ~/data_lg/czbiohub-reference/ensembl/release-97/fasta/homo_sapiens/pep/Homo_sapiens.GRCh38.pep.all.fa.gz \
+		--ksizes 21 \
+		--log2_sketch_sizes 5 \
+		--extract_coding_peptide_ksize 7 \
+		--extract_coding_peptide_molecule protein \
+		--outdir ~/data_sm/kmer-hashing/kmermaid-extract-coding-ensembl97/ \
+		--extract_coding_jaccard_threshold 0.5 \
+		-work-dir ~/data_sm/olga-lrrr/nextflow-intermediates-nosudo/ \
+		--max_cpus 120 \
+		--max_time 720.h \
+		-resume

--- a/kmermaid/nextflow.config
+++ b/kmermaid/nextflow.config
@@ -5,4 +5,5 @@ executor {
 
 process {
   errorStrategy = 'ignore'
+  container = 'nfcore/kmermaid:khtools-extract-coding-long-reads'
 }

--- a/kmermaid/nextflow.config
+++ b/kmermaid/nextflow.config
@@ -1,0 +1,8 @@
+executor {
+   cpus = 120
+   memory = '1024 GB'
+}
+
+process {
+  errorStrategy = 'ignore'
+}


### PR DESCRIPTION
Use frankenbranch ( https://github.com/czbiohub/kh-tools/pull/19) of https://github.com/czbiohub/kh-tools/pull/18, https://github.com/czbiohub/kh-tools/pull/16, and https://github.com/czbiohub/kh-tools/pull/15 to run extract_coding on all of ENSEMBL97 cds sequences as a gold standard