### PR TITLE
hulk makefile

### DIFF
--- a/nf-kmer-similarity/Makefile_hulk_k2g
+++ b/nf-kmer-similarity/Makefile_hulk_k2g
@@ -1,0 +1,37 @@
+BASE=/data_lg/olga/kmer-hashing/golumbeanu2018
+PEPTIDE_DIR=/data_sm/home/pranathi/code/k2g/data/
+NO_K2G_FASTA=${PEPTIDE_DIR}/KS_UniProt_HumanProteomeSPonly_HIV_KtoG_appended_KS20200323correct__non-k2g.fasta
+K2G_FASTA=${PEPTIDE_DIR}/KS_UniProt_HumanProteomeSPonly_HIV_KtoG_appended_KS20200323correct__k2g.fasta
+OUTDIR_BASE=${BASE}/kmermaid_k2g_lrrr_sep24/
+FASTA_DIR=${BASE}rawdata
+WORK_DIR=/data_lg/pranathi/nextflow-work-lrrr-k2g/
+DATA_DIR=${BASE}/rawdata/fastqs
+
+COMMON_FLAGS=nf-core/kmermaid \
+		-r pranathivemuri-patch-1 \
+		-latest \
+		--molecules dna,protein,dayhoff,hp \
+		--ksizes '21,27,33,39,51,63,93' \
+		--sketch_scaled 10,50,100,500 \
+		--read_singles ${DATA_DIR}/'*.fastq.gz' \
+		-w ${WORK_DIR} \
+		--save_intermediate_dir /data_lg/pranathi/k2g_intermediate/ \
+		--translate_peptide_ksize 15 \
+		--max_cpus 2 -resume --max_memory 8.GB --max_time 96.h \
+		--tenx_min_umi_per_cell 5001 \
+		--track_abundance -with-tower
+
+
+no_k2g_uniprot:
+	nextflow run \
+		${COMMON_FLAGS} \
+		--outdir ${OUTDIR_BASE}/$@ \
+		--reference_proteome_fasta ${NO_K2G_FASTA}
+
+
+
+with_k2g_uniprot:
+	nextflow run \
+		${COMMON_FLAGS} \
+		--outdir ${OUTDIR_BASE}/$@ \
+		--reference_proteome_fasta ${K2G_FASTA}

--- a/nf-kmer-similarity/Makefile_hulk_k2g
+++ b/nf-kmer-similarity/Makefile_hulk_k2g
@@ -12,7 +12,7 @@ COMMON_FLAGS=nf-core/kmermaid \
 		-latest \
 		--molecules dna,protein,dayhoff,hp \
 		--ksizes '21,27,33,39,51,63,93' \
-		--sketch_scaled 10,50,100,500 \
+		--sketch_scaled 50,100,500 \
 		--read_singles ${DATA_DIR}/'*.fastq.gz' \
 		-w ${WORK_DIR} \
 		--save_intermediate_dir /data_lg/pranathi/k2g_intermediate/ \

--- a/nf-kmer-similarity/nextflow.config
+++ b/nf-kmer-similarity/nextflow.config
@@ -1,55 +1,24 @@
-docker.enabled = true
-
-timeline {
-  enabled = true
+executor {
+	 cpus = 32
+	 time = 99999999.h
 }
-report {
-  enabled = true
-}
-trace {
-  enabled = true
-}
-dag {
-  enabled = true
-}
-
-latest = true
-
-profiles {
-
-  local {
-    process.executor = 'local'
+process {
+  withName: 'translate' {
+    memory = 16.GB
+    cpus = 4
+    time = 99999999999.h
   }
-
-  aws {
-    process.executor = 'awsbatch'
-    process.queue = 'nextflow'
-    executor.awscli = '/home/ec2-user/miniconda/bin/aws'
-    workDir = 's3://kmer-hashing/nextflow-intermediates/'
-    docker.enabled = true
+  withName: 'sourmash_compute_sketch_fastx_peptide' {
+    memory = 16.GB
+    cpus = 4
+    time = 99999999999.h
+  }
+  withName: 'sourmash_compute_sketch_fastx_nucleotide' {
+    memory = 16.GB
+    cpus = 4
+    time = 99999999999.h
+  }
+  withName: 'multiqc' {
+    errorStrategy = 'ignore'
   }
 }
-
-
-aws {
-	region = 'us-west-2'
-
-    client {
-        maxConnections = 20
-        connectionTimeout = 10000
-        uploadStorageClass = 'INTELLIGENT_TIERING'
-        storageEncryption = 'AES256'
-    }
-}
-
-// cloud {
-//       // Amazon ECS-optimized Nextflow image with AWS cli
-//     imageId = 'ami-0c323ba3e98b979f9'
-//     instanceType = 'm4.xlarge'
-//     // subnetId = 'subnet-05222a43'
-//     autoscale {
-//               enabled = true
-//               maxInstances = 20
-//               terminateWhenIdle = true
-//               }
-// }


### PR DESCRIPTION
```
(nfcore-kmermaid-1.0.0dev-p9) -bash-4.2$ make -f Makefile_hulk_k2g                                                                                      
nextflow run \
        nf-core/kmermaid -r pranathivemuri-patch-1 -latest --molecules dna,protein,dayhoff,hp --ksizes '21,27,33,39,51,63,93' --sketch_scaled 10,50,100,500 --read_singles /data_lg/olga/kmer-hashing/golumbeanu2018/rawdata/fastqs/'*.fastq.gz' -w /data_lg/pranathi/nextflow-work-lrrr-k2g/ --save_intermediate_dir /data_lg/pranathi/k2g_intermediate/ --translate_peptide_ksize 15 --max_cpus 2 -resume --max_memory 8.GB --max_time 96.h --tenx_min_umi_per_cell 5001 --track_abundance -with-tower \
        --outdir /data_lg/olga/kmer-hashing/golumbeanu2018/kmermaid_k2g_lrrr_sep24//no_k2g_uniprot \
        --reference_proteome_fasta /data_sm/home/pranathi/code/k2g/data//KS_UniProt_HumanProteomeSPonly_HIV_KtoG_appended_KS20200323correct__non-k2g.fasta
N E X T F L O W  ~  version 20.01.0-rc1
Pulling nf-core/kmermaid ...
Already-up-to-date
Launching `nf-core/kmermaid` [cranky_euler] - revision: d0e3ac429c [pranathivemuri-patch-1]
WARN: Nextflow version 20.01.0-rc1 does not match workflow required version: >=20.07.1 -- Execution will continue, but things may break!
----------------------------------------------------
                                        ,--./,-.
        ___     __   __   __   ___     /,-._.--~'
  |\ | |__  __ /  ` /  \ |__) |__         }  {
  | \| |       \__, \__/ |  \ |___     \`-._,-`-,
                                        `._,._,'
  nf-core/kmermaid v1.0.0dev
----------------------------------------------------
Pipeline Release  : pranathivemuri-patch-1
Run Name          : cranky_euler
Single-end reads  : /data_lg/olga/kmer-hashing/golumbeanu2018/rawdata/fastqs/*.fastq.gz
Skip trimming?    : false
Skip compare?     : false
Skip compute?     : false
Skip multiqc?     : false
K-mer sizes       : 21,27,33,39,51,63,93
Molecule          : dna,protein,dayhoff,hp
Track Abundance   : true
Sketch scaled     : 10,50,100,500
Peptide fasta     : /data_sm/home/pranathi/code/k2g/data//KS_UniProt_HumanProteomeSPonly_HIV_KtoG_appended_KS20200323correct__non-k2g.fasta
Peptide ksize     : 15
Peptide molecule  : protein
Bloom filter table size: 1e8
Max Resources     : 8.GB memory, 2 cpus, 96.h time per job
Output dir        : /data_lg/olga/kmer-hashing/golumbeanu2018/kmermaid_k2g_lrrr_sep24//no_k2g_uniprot
Launch dir        : /data_sm/home/pranathi/code/kh-workflows/nf-kmer-similarity
Working dir       : /data_lg/pranathi/nextflow-work-lrrr-k2g
Script dir        : /data_sm/home/pranathi/.nextflow/assets/nf-core/kmermaid
User              : pranathi
Config Profile    : standard
----------------------------------------------------
Monitor the execution with Nextflow Tower using this url https://tower.nf/watch/LG0NvoQoEAih6
executor >  local (15)
[3f/d85e06] process > get_software_versions                    [100%] 1 of 1 ✔
[ae/d5878c] process > validate_sketch_values                   [100%] 1 of 1 ✔
[ae/6424e8] process > make_protein_index                       [100%] 1 of 1 ✔
[aa/49e53e] process > fastp                                    [  0%] 0 of 12
[-        ] process > translate                                -
[-        ] process > sourmash_compute_sketch_fastx_nucleotide -
[-        ] process > sourmash_compute_sketch_fastx_peptide    -
[-        ] process > sourmash_compare_sketches                -
[-        ] process > multiqc                                  -
```